### PR TITLE
Fixed deprecations in Symfony 4.2 and highter

### DIFF
--- a/DependencyInjection/Configuration.php
+++ b/DependencyInjection/Configuration.php
@@ -17,9 +17,16 @@ class Configuration implements ConfigurationInterface
      */
     public function getConfigTreeBuilder()
     {
-        $treeBuilder = new TreeBuilder();
-                
-        $treeBuilder->root('symfony_sphinx')
+        $treeBuilder = new TreeBuilder('symfony_sphinx');
+
+        if (method_exists($treeBuilder, 'getRootNode')) {
+            $rootNode = $treeBuilder->getRootNode();
+        } else {
+            // BC layer for symfony/config 4.1 and older
+            $rootNode = $treeBuilder->root('symfony_sphinx');
+        }
+
+        $rootNode
             ->children()
                 ->scalarNode('host')->defaultValue('127.0.0.1')->end()
                 ->scalarNode('port')->defaultValue(9306)->end()


### PR DESCRIPTION
> A tree builder without a root node is deprecated since Symfony 4.2 and will not be supported anymore in 5.0.

> The "Symfony\Component\Config\Definition\Builder\TreeBuilder::root()" method called for the "symfony_sphinx" configuration is deprecated since Symfony 4.3, pass the root name to the constructor instead.