### PR TITLE
Update services.yml

### DIFF
--- a/Resources/config/services.yml
+++ b/Resources/config/services.yml
@@ -26,4 +26,4 @@ services:
             - '%sphinx.port%'
 
     sphinx.manager:
-        class: '@Pluk77\SymfonySphinxBundle\Sphinx\Manager' 
+        class: Pluk77\SymfonySphinxBundle\Sphinx\Manager

--- a/Resources/config/services.yml
+++ b/Resources/config/services.yml
@@ -25,5 +25,4 @@ services:
             - '%sphinx.host%'
             - '%sphinx.port%'
 
-    sphinx.manager:
-        class: Pluk77\SymfonySphinxBundle\Sphinx\Manager
+    sphinx.manager: '@Pluk77\SymfonySphinxBundle\Sphinx\Manager'

--- a/Resources/config/services.yml
+++ b/Resources/config/services.yml
@@ -26,4 +26,4 @@ services:
             - '%sphinx.port%'
 
     sphinx.manager:
-        class: 'Pluk77\SymfonySphinxBundle\Sphinx\Manager' 
+        class: '@Pluk77\SymfonySphinxBundle\Sphinx\Manager' 

--- a/Resources/config/services.yml
+++ b/Resources/config/services.yml
@@ -25,4 +25,5 @@ services:
             - '%sphinx.host%'
             - '%sphinx.port%'
 
-    sphinx.manager: '@Pluk77\SymfonySphinxBundle\Sphinx\Manager' 
+    sphinx.manager:
+        class: 'Pluk77\SymfonySphinxBundle\Sphinx\Manager' 


### PR DESCRIPTION
On symfony 5.2.0 i have error

Script cache:clear returned with error code 1
!!  
!!  In YamlFileLoader.php line 745:
!!                                                                                 
!!    The file "vendor/pluk77/symfony-sphinx-bundle/Depend  
!!    encyInjection/../Resources/config/services.yml" does not contain valid YAML  
!!    : Malformed inline YAML string at line 28 (near "sphinx.manager: '@Pluk77\S  
!!    ymfonySphinxBundle\Sphinx\Manager' ")                                        
!!                                                                                 
!!  
!!  In Parser.php line 1216:
!!                                                                                 
!!    Malformed inline YAML string at line 28 (near "sphinx.manager: '@Pluk77\Sym  
!!    fonySphinxBundle\Sphinx\Manager' ")